### PR TITLE
[DEV-463] - Add perms for oidc auth

### DIFF
--- a/.github/workflows/docker_build_test_scan_push.yml
+++ b/.github/workflows/docker_build_test_scan_push.yml
@@ -26,6 +26,9 @@ on:
         description: 'DevOps Github machine user personal access token'
         required: false
 
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   docker_build_test_scan_push:


### PR DESCRIPTION
Add perms for oidc auth. Missed from https://github.com/vergesense/gha-docker-build-test-scan-push/pull/6.

https://vergesense.atlassian.net/browse/DEV-463